### PR TITLE
Show correct status indicators

### DIFF
--- a/src/components/Dashboard/Overview.tsx
+++ b/src/components/Dashboard/Overview.tsx
@@ -216,7 +216,7 @@ const DashboardOverview = () => {
               font-size: ${rem(20)};
             `}
           >
-            {expansion.gt(0) || true ? "Expansion" : "Debt"}
+            {expansion.gt(0) ? "Expansion" : "Debt"}
           </Title>
           <Spacer size={24} />
         </Block>

--- a/src/components/Stats/index.tsx
+++ b/src/components/Stats/index.tsx
@@ -72,7 +72,7 @@ const Stats = () => {
   const poolStagedZai = stagedPercentOfPool.times(pairBalanceZai)
 
   const supplyText =
-    twapPrice.gt(1) || true
+    twapPrice.gt(1)
       ? 'total supply will expand by'
       : 'protocol debt will increase by'
 


### PR DESCRIPTION
## Description

This PR fixes a bug where the dashboard site was always showing the that the status of the token is expanding.

This was happening because someone left ` || true` in the status condition check, which would force the display to always think the system was in expansion.

Note that this does not fix any bugs in the actual token system, just makes the dashboard display correctly.